### PR TITLE
Add test case for behavior that I think text_body ought to have

### DIFF
--- a/t/body_utf8.t
+++ b/t/body_utf8.t
@@ -47,4 +47,37 @@ is $warn, "", "decoded perl unicode string causes no warnings";
 is $res->body_str, $c, "body didn't get corrupted";
 is $warn, "", "decoded perl unicode string causes no warnings";
 
+subtest text_body => sub {
+	my @methods= (
+		[ "via old create API",
+		  sub { Email::MIME->create( @core,
+				body => $d, body_attributes => { charset => "UTF-8" },
+				text_body => $e, text_body_attributes => { charset => "shiftjis" },
+		  )},
+		],
+		[ "via new create API, but use pre-encoded strings like in old API",
+		  sub { Email::MIME::CreateHTML->create( @core,
+				body => $d, body_attributes => { charset => "UTF-8" },
+				text_body => $e, text_body_attributes => { charset => "shiftjis" },
+		  )},
+		],
+		[ "via new create API, with perl unicode strings",
+		  sub { Email::MIME::CreateHTML->create( @core,
+				body_str => $c, body_attributes => { charset => "UTF-8" },
+				text_body_str => $c, text_body_attributes => { charset => "shiftjis" },
+		  )},
+		],
+	);
+	for (@methods) {
+		my ($name, $sub)= @$_;
+		subtest $name => sub {
+			( undef, $warn, $res ) = &capture($sub);
+			is( ($res->subparts)[0]->body_str, $c, 'text body not corrupted' );
+			is( ($res->subparts)[0]->body,     $e, 'text body encoded as shiftjis' );
+			is( ($res->subparts)[1]->body_str, $c, 'html body not corrupted' );
+			is( ($res->subparts)[1]->body,     $d, 'html body encoded as utf-8' );
+		};
+	}
+};
+
 done_testing;


### PR DESCRIPTION
I think the fixes you added for text_body don't quite match the behavior of the original module, and also don't quite mirror the body and body_str attributes in the way I was trying to describe.  Here's a test case that shows what I was talking about.